### PR TITLE
🔀 :: (#100) - 수정한 다이얼로그 버튼 색이 제데로 적용되지 않았던 오류 수정

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -42,8 +42,7 @@
         <activity
             android:name="com.goms.presentation.view.profile.ProfileActivity"
             android:screenOrientation="portrait"
-            android:exported="false"
-            android:theme="@style/Theme.GSM_GOMS" />
+            android:exported="false" />
         <activity
             android:name="com.goms.presentation.view.sign_in.SignInActivity"
             android:screenOrientation="portrait"
@@ -52,8 +51,7 @@
         <activity
             android:name="com.goms.presentation.view.main.MainActivity"
             android:screenOrientation="portrait"
-            android:exported="true"
-            android:theme="@style/Theme.GSM_GOMS" />
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/presentation/src/main/java/com/goms/presentation/view/profile/ProfileActivity.kt
+++ b/presentation/src/main/java/com/goms/presentation/view/profile/ProfileActivity.kt
@@ -20,6 +20,7 @@ class ProfileActivity : AppCompatActivity() {
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setTheme()
 
         binding = ActivityProfileBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -53,5 +54,12 @@ class ProfileActivity : AppCompatActivity() {
         binding.profileCardUserNumberText.text = profileData?.studentNum?.number.toString()
         binding.profileCardUserLateCountText.text = profileData?.lateCount.toString()
         binding.profileUserCircleImage.load(profileData?.profileUrl ?: R.drawable.user_profile)
+    }
+
+    private fun setTheme() {
+        val authorityPreferences = getSharedPreferences("authority", MODE_PRIVATE)
+        val role = authorityPreferences.getString("role", "").toString()
+        if (role == "ROLE_STUDENT") super.setTheme(R.style.Theme_GSM_GOMS)
+        else super.setTheme(R.style.Theme_GSM_GOMS_ADMIN)
     }
 }


### PR DESCRIPTION
## 💡 개요
이전에 수정했던 다이얼로그 버튼 오류가 재발생
## 📃 작업내용
불필요한 테마 적용 코드 삭제
다이얼로그의 부모(?) activity에 테마 적용 추가
## 🔀 변경사항
manifest 코드 제거
프로필 activity에서 테마 적용 코드 추가
## 🙋‍♂️ 질문사항
